### PR TITLE
Add new specialized defaults

### DIFF
--- a/vue-mode.el
+++ b/vue-mode.el
@@ -6,7 +6,7 @@
 ;; Keywords: languages
 
 ;; Version: 0.2
-;; Package-Requires: ((mmm-mode "0.5.4"))
+;; Package-Requires: ((mmm-mode "0.5.4") (vue-html-mode "0.1") (ssass-mode "0.1"))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -28,6 +28,8 @@
 ;;; Code:
 
 (require 'mmm-mode)
+(require 'vue-html-mode)
+(require 'ssass-mode)
 
 (defgroup vue nil
   "Group for vue-mode"
@@ -37,8 +39,8 @@
   :link '(emacs-commentary-link :tag "Commentary" "vue-mode"))
 
 (defcustom vue-modes
-  '((:type template :name nil :mode web-mode)
-    (:type template :name html :mode html-mode)
+  '((:type template :name nil :mode vue-html-mode)
+    (:type template :name html :mode vue-html-mode)
     (:type template :name jade :mode jade-mode)
     (:type template :name pug :mode pug-mode)
     (:type script :name nil :mode js-mode)
@@ -52,7 +54,7 @@
     (:type style :name stylus :mode stylus-mode)
     (:type style :name less :mode less-css-mode)
     (:type style :name scss :mode scss-mode)
-    (:type style :name sass :mode sass-mode))
+    (:type style :name sass :mode ssass-mode))
   "A list of vue component languages, their type, and their corresponding major modes"
   :type '(list (plist :type 'symbol :name 'symbol :mode 'function))
   :group 'vue)


### PR DESCRIPTION
vue-html-mode adds some extra syntax highlighting to vue templates, and ssass-mode is a clone of sass-mode which works in mmm-mode.

I'm not 100% sure about the dependency format, but I'm not sure how one would test that without getting melpa to build it.