### PR TITLE
Let SCSS be handled by the builtin css-mode

### DIFF
--- a/vue-mode.el
+++ b/vue-mode.el
@@ -53,7 +53,7 @@
     (:type style :name css :mode css-mode)
     (:type style :name stylus :mode stylus-mode)
     (:type style :name less :mode less-css-mode)
-    (:type style :name scss :mode scss-mode)
+    (:type style :name scss :mode css-mode)
     (:type style :name sass :mode ssass-mode))
   "A list of vue component languages, their type, and their corresponding major modes"
   :type '(list (plist :type 'symbol :name 'symbol :mode 'function))


### PR DESCRIPTION
As per https://github.com/antonj/scss-mode/issues/36, the syntax highlighting of `scss-mode` is broken in newer emacs. Newer emacs also includes SCSS support with the builtin `css-mode`, so there is no need to specify that SCSS should be handled by the older mode.